### PR TITLE
bump up speedtest-cli version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ LABEL MAINTAINER=AwEi \
       GITHUB="https://github.com/chenwei791129/docker-speedtest-cli" \
       DOCKERHUB="https://hub.docker.com/r/awei/speedtest-cli"
 
-ENV CLI_VERSION=2.1.2
+ENV CLI_VERSION=2.1.3
 
 RUN pip install --no-cache-dir speedtest-cli==${CLI_VERSION}
 


### PR DESCRIPTION
in order to handle case where `ignoreids` is empty or contains empty
ids. See https://github.com/sivel/speedtest-cli/commit/cadc68b5aef20f28648072cf07a8f155639b81dd for details.

Signed-off-by: Andreas Schmid <service@aaschmid.de>